### PR TITLE
Update teams page hexagon design

### DIFF
--- a/src/components/team/TeamHive.tsx
+++ b/src/components/team/TeamHive.tsx
@@ -60,43 +60,38 @@ const teamMembers: TeamMember[] = [
 export default function TeamHive() {
   return (
     <div className="flex justify-center items-center min-h-[600px]">
-      <div className="relative w-fit">
-        {/* First row - 3 hexagons */}
-        <div className="flex justify-center mb-[-2.375rem] relative ml-[4.8rem]">
-          {teamMembers.slice(0, 3).map((member, index) => (
-            <TeamMemberHex
-              key={member.id}
-              member={member}
-              className="mr-1"
-            />
-          ))}
+      <div className="relative">
+        {/* Row 1: 2 hexagons */}
+        <div className="flex justify-center relative">
+          <div className="mr-[-0.75rem]">
+            <TeamMemberHex member={teamMembers[0]} />
+          </div>
+          <div>
+            <TeamMemberHex member={teamMembers[1]} />
+          </div>
         </div>
         
-        {/* Second row - 4 hexagons */}
-        <div className="flex justify-center mb-[-2.375rem] relative">
-          {teamMembers.slice(3, 7).map((member, index) => (
-            <TeamMemberHex
-              key={member.id}
-              member={member}
-              className="mr-1"
-            />
-          ))}
+        {/* Row 2: 3 hexagons - offset and overlapping */}
+        <div className="flex justify-center relative mt-[-2.2rem] ml-[-2.4rem]">
+          <div className="mr-[-0.75rem]">
+            <TeamMemberHex member={teamMembers[2]} />
+          </div>
+          <div className="mr-[-0.75rem]">
+            <TeamMemberHex member={teamMembers[3]} />
+          </div>
+          <div>
+            <TeamMemberHex member={teamMembers[4]} />
+          </div>
         </div>
         
-        {/* Third row - 3 hexagons */}
-        <div className="flex justify-center relative ml-[4.8rem]">
-          {teamMembers.slice(0, 3).map((member, index) => (
-            <TeamMemberHex
-              key={`bottom-${member.id}`}
-              member={{
-                ...member,
-                name: `Team Member ${index + 8}`,
-                position: "Position",
-                id: member.id + 10
-              }}
-              className="mr-1"
-            />
-          ))}
+        {/* Row 3: 2 hexagons - back to 2, interlocked */}
+        <div className="flex justify-center relative mt-[-2.2rem]">
+          <div className="mr-[-0.75rem]">
+            <TeamMemberHex member={teamMembers[5]} />
+          </div>
+          <div>
+            <TeamMemberHex member={teamMembers[6]} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/team/TeamMemberHex.tsx
+++ b/src/components/team/TeamMemberHex.tsx
@@ -28,7 +28,7 @@ export default function TeamMemberHex({ member, className }: TeamMemberHexProps)
       >
         {/* Front face - Image */}
         <div
-          className="absolute inset-0 w-full h-full bg-gradient-to-br from-primary/20 to-primary/40 shadow-lg hover:shadow-xl transition-shadow duration-300"
+          className="absolute inset-0 w-full h-full bg-gradient-to-br from-yellow-400/30 to-amber-500/50 shadow-lg hover:shadow-xl transition-shadow duration-300"
           style={{
             clipPath: 'polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)',
             backfaceVisibility: 'hidden'
@@ -41,8 +41,8 @@ export default function TeamMemberHex({ member, className }: TeamMemberHexProps)
             }}
           >
             {/* Placeholder for image - you can replace this with actual images later */}
-            <div className="w-full h-full bg-gradient-to-br from-blue-400 to-purple-500 flex items-center justify-center">
-              <div className="text-white text-2xl font-bold">
+            <div className="w-full h-full bg-gradient-to-br from-yellow-400 to-amber-500 flex items-center justify-center">
+              <div className="text-white text-2xl font-bold drop-shadow-md">
                 {member.name.split(' ').map(n => n[0]).join('')}
               </div>
             </div>
@@ -51,7 +51,7 @@ export default function TeamMemberHex({ member, className }: TeamMemberHexProps)
 
         {/* Back face - Info */}
         <div
-          className="absolute inset-0 w-full h-full bg-gradient-to-br from-secondary/90 to-secondary shadow-lg"
+          className="absolute inset-0 w-full h-full bg-gradient-to-br from-yellow-500/95 to-amber-600/95 shadow-lg"
           style={{
             clipPath: 'polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)',
             backfaceVisibility: 'hidden',
@@ -59,15 +59,15 @@ export default function TeamMemberHex({ member, className }: TeamMemberHexProps)
           }}
         >
           <div
-            className="w-full h-full flex flex-col items-center justify-center p-4 text-center text-secondary-foreground"
+            className="w-full h-full flex flex-col items-center justify-center p-4 text-center text-white"
             style={{
               clipPath: 'polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)'
             }}
           >
-            <h3 className="font-bold text-sm mb-1 leading-tight">
+            <h3 className="font-bold text-sm mb-1 leading-tight drop-shadow-sm">
               {member.name}
             </h3>
-            <p className="text-xs opacity-90 leading-tight">
+            <p className="text-xs opacity-90 leading-tight drop-shadow-sm">
               {member.position}
             </p>
           </div>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update team page hexagons to yellow and implement a proper interlocked beehive pattern.

---

[Open in Web](https://cursor.com/agents?id=bc-537e3731-1238-412b-a78b-6ed94b3b7859) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-537e3731-1238-412b-a78b-6ed94b3b7859) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)