### PR TITLE
Update teams page hexagon design

### DIFF
--- a/src/components/team/TeamMemberHex.tsx
+++ b/src/components/team/TeamMemberHex.tsx
@@ -24,30 +24,41 @@ export default function TeamMemberHex({ member, className }: TeamMemberHexProps)
       }}
     >
       <div className="relative w-[150px] h-[150px]">
-        {/* Front face - Image */}
+        {/* Front face - Picture */}
         <div
-          className="absolute inset-0 w-full h-full bg-gradient-to-br from-yellow-400/30 to-amber-500/50 shadow-lg hover:shadow-xl transition-shadow duration-300"
+          className="absolute inset-0 w-full h-full bg-gradient-to-br from-yellow-400/20 to-amber-500/30 shadow-lg hover:shadow-xl transition-shadow duration-300"
           style={{
             clipPath: 'polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)',
             backfaceVisibility: 'hidden'
           }}
         >
           <div
-            className="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center overflow-hidden"
+            className="w-full h-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center overflow-hidden relative"
             style={{
               clipPath: 'polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)'
             }}
           >
-            {/* Placeholder for image - you can replace this with actual images later */}
-            <div className="w-full h-full bg-gradient-to-br from-yellow-400 to-amber-500 flex items-center justify-center">
-              <div className="text-white text-2xl font-bold drop-shadow-md">
-                {member.name.split(' ').map(n => n[0]).join('')}
+            {/* Picture placeholder - this will be replaced with actual images */}
+            <div className="w-full h-full bg-gradient-to-br from-gray-300 to-gray-400 dark:from-gray-600 dark:to-gray-700 flex items-center justify-center">
+              <div className="text-gray-600 dark:text-gray-300 text-6xl">
+                👤
               </div>
             </div>
+            
+            {/* Optional: Image element for when you have actual photos */}
+            {/* <Image 
+              src={member.image} 
+              alt={member.name}
+              fill
+              className="object-cover"
+              style={{
+                clipPath: 'polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)'
+              }}
+            /> */}
           </div>
         </div>
 
-        {/* Back face - Info */}
+        {/* Back face - Name and Position */}
         <div
           className="absolute inset-0 w-full h-full bg-gradient-to-br from-yellow-500/95 to-amber-600/95 shadow-lg"
           style={{
@@ -62,10 +73,10 @@ export default function TeamMemberHex({ member, className }: TeamMemberHexProps)
               clipPath: 'polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)'
             }}
           >
-            <h3 className="font-bold text-sm mb-1 leading-tight drop-shadow-sm">
+            <h3 className="font-bold text-base mb-2 leading-tight drop-shadow-sm">
               {member.name}
             </h3>
-            <p className="text-xs opacity-90 leading-tight drop-shadow-sm">
+            <p className="text-sm opacity-90 leading-tight drop-shadow-sm">
               {member.position}
             </p>
           </div>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update team member hexagons to display a picture on the front face and name/position on the back face when flipped.

---

[Open in Web](https://cursor.com/agents?id=bc-537e3731-1238-412b-a78b-6ed94b3b7859) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-537e3731-1238-412b-a78b-6ed94b3b7859) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)